### PR TITLE
colors: make statusline match Acme tagline

### DIFF
--- a/colors/vacme.lua
+++ b/colors/vacme.lua
@@ -37,7 +37,7 @@ local vcolors = {
 	m2 = {term='5',hex='#8888C7'},
 
 	-- cyans
-	c1 = {term='194',hex='#EEFEFF'},
+	c1 = {term='194',hex='#EAFFFF'},
 	c2 = {term='14',hex='#B0ECED'},
 	c3 = {term='6',hex='#6AA7A8'},
 
@@ -84,8 +84,8 @@ syntax('DiffAdd', {fg=vcolors.w4, bg=vcolors.g2})
 syntax('DiffChange', {fg=vcolors.w4, bg=vcolors.c2})
 syntax('DiffDelete', {fg=vcolors.w4, bg=vcolors.r1})
 syntax('DiffText', {fg=vcolors.w4, bg=vcolors.g2})
-syntax('StatusLine', {fg=vcolors.w4, bg=vcolors.b1, style='bold,underline'})
-syntax('StatusLineNC', {fg=vcolors.w4, bg=vcolors.b1})
+syntax('StatusLine', {fg=vcolors.w4, bg=vcolors.c1, style='bold,underline'})
+syntax('StatusLineNC', {fg=vcolors.w4, bg=vcolors.c1})
 link('TabLine', 'StatusLineNC')
 link('TabLineFill', 'StatusLineNC')
 link('WinSeparator', 'StatusLineNC')


### PR DESCRIPTION
This commit makes the statusline use the cyan color base, which is closer to what Acme uses in its tagline ("menu").  Finally, it adjusts the cyan base color to more closely match the color value encoded in the original implementation: #EAFFFF.

Acme looks like this:

![](https://upload.wikimedia.org/wikipedia/commons/9/98/Acme.png)

vacme at `HEAD` looks like this (iTerm):

<img width="727" height="478" alt="Bildschirmfoto 2025-08-27 um 18 34 08" src="https://github.com/user-attachments/assets/2a8382f0-d5a0-4f8d-a902-3a9faec07064" />

With this change, it appears closer to Acme above and [your blog post](https://raphael-proust.github.io/code/acme-theme.html):

<img width="727" height="500" alt="Bildschirmfoto 2025-08-27 um 18 29 17" src="https://github.com/user-attachments/assets/57d95cb4-b5aa-40d3-a6dd-1f23d823cd2c" />

Either way, thank you for the theme and thoughtful matching.  It looks really great to my eyes, except this one discrepancy keeps sticking out to me each day.  ;-)
