### PR TITLE
set background='light'

### DIFF
--- a/colors/vacme.lua
+++ b/colors/vacme.lua
@@ -5,6 +5,7 @@ if vim.fn.exists("syntax_on") then
 end
 
 vim.g.colors_name = 'vacme'
+vim.o.background = 'light'
 
 local vcolors = {
 	-- whites


### PR DESCRIPTION
Hi, 

I noticed that in some cases (like when using the nvy frontend) the background option defaults to 'dark', so the theme doesn’t apply properly. Setting the background option explicitly seems to fix it.
